### PR TITLE
Modificado str por basestring dessa forma aceita unicode strings

### DIFF
--- a/pyboleto/data.py
+++ b/pyboleto/data.py
@@ -189,18 +189,18 @@ class BoletoData(object):
         """
 
         for attr, length, data_type in [
-            ('codigo_banco', 3, str),
-            ('moeda', 1, str),
+            ('codigo_banco', 3, basestring),
+            ('moeda', 1, basestring),
             ('data_vencimento', None, datetime.date),
-            ('valor_documento', -1, str),
-            ('campo_livre', 25, str),
+            ('valor_documento', -1, basestring),
+            ('campo_livre', 25, basestring),
             ]:
             value = getattr(self, attr)
             if not isinstance(value, data_type):
                 raise TypeError("%s.%s must be a %s, got %r (type %s)" % (
                     self.__class__.__name__, attr, data_type.__name__, value,
                     type(value).__name__))
-            if data_type == str and length != -1 and len(value) != length:
+            if data_type == basestring and length != -1 and len(value) != length:
                 raise ValueError(
                     "%s.%s must have a length of %d, not %r (len: %d)" % (
                     self.__class__.__name__, attr, length, value, len(value)))


### PR DESCRIPTION
Quando é passado uma string do tipo unicode para o campo_livre na hora de gerar a linha digitável ocorre o erro abaixo:

![capturar](https://cloud.githubusercontent.com/assets/854781/5331226/2b4a64e2-7e07-11e4-9c5b-4008927a5487.PNG)

Com a modificação de str para basestring o teste issintance funciona tanto para str quanto unicode.

