### PR TITLE
correçao de erro ao tentar imprimir boleto usando o django 1.8

### DIFF
--- a/pyboleto/django/admin.py
+++ b/pyboleto/django/admin.py
@@ -21,7 +21,7 @@ def print_boletos(modeladmin, request, queryset):
 
     pdf_file = buffer.getvalue()
 
-    response = HttpResponse(mimetype='application/pdf')
+    response = HttpResponse()
     response['Content-Disposition'] = 'attachment; filename=%s' % (
         u'boletos_%s.pdf' % (
             date.today().strftime('%Y%m%d'),


### PR DESCRIPTION
No django 1.8 o HttpResponse não aceita argumentos no __init__(), então removir o argumento e funcionou.