### PR TITLE
Compatibilidade com o Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,10 @@ Executing unittests
 You need either setuptools or distribute in order to execute the tests. Chances are you already have one or another. You also need `pdftohtml`_.::
 
     $ cd pyboleto
-    $ python setup.py test
+    $ python2 setup.py test
+	$ python3 -W ignore:ResourceWarning setup.py test
 
+Resource warning is default since Python 3.4, and some libraries have a lot of warnings because of this.
 
 .. _pdftohtml: http://poppler.freedesktop.org/
 

--- a/bin/pdf_pyboleto_sample.py
+++ b/bin/pdf_pyboleto_sample.py
@@ -253,31 +253,31 @@ def print_itau():
 
 
 def print_all():
-    print "Pyboleto version: %s" % pyboleto.__version__
-    print "----------------------------------"
-    print "     Printing Example Boletos     "
-    print "----------------------------------"
+    print("Pyboleto version: %s" % pyboleto.__version__)
+    print("----------------------------------")
+    print("     Printing Example Boletos     ")
+    print("----------------------------------")
 
-    print "Banco do Brasil"
+    print("Banco do Brasil")
     print_bb()
 
-    print "Bradesco"
+    print("Bradesco")
     print_bradesco()
 
-    #print "Itau"
+    #print("Itau")
     #print_itau()
 
-    print "Caixa"
+    print("Caixa")
     print_caixa()
 
-    print "Real"
+    print("Real")
     print_real()
 
-    print "Santander"
+    print("Santander")
     print_santander()
 
-    print "----------------------------------"
-    print "Ok"
+    print("----------- ----------------------")
+    print("Ok")
 
 
 if __name__ == "__main__":

--- a/pyboleto/data.py
+++ b/pyboleto/data.py
@@ -10,8 +10,12 @@
     :license: BSD, see LICENSE for more details.
 
 """
+import sys
 import datetime
 from decimal import Decimal
+
+if sys.version_info >= (3,):
+    basestring = (str, bytes)
 
 
 class BoletoException(Exception):
@@ -307,7 +311,7 @@ class BoletoData(object):
         if type(val) is Decimal:
             self._valor = val
         else:
-            self._valor = Decimal(str(val), 2)
+            self._valor = Decimal(str(val))
     valor = property(_get_valor, _set_valor)
     """Valor convertido para :class:`Decimal`.
 
@@ -325,7 +329,7 @@ class BoletoData(object):
         if type(val) is Decimal:
             self._valor_documento = val
         else:
-            self._valor_documento = Decimal(str(val), 2)
+            self._valor_documento = Decimal(str(val))
     valor_documento = property(_get_valor_documento, _set_valor_documento)
     """Valor do Documento convertido para :class:`Decimal`.
 

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -10,6 +10,7 @@
 
 """
 import os
+import sys
 
 from reportlab.graphics.barcode.common import I2of5
 from reportlab.lib.colors import black
@@ -17,6 +18,9 @@ from reportlab.lib.pagesizes import A4, landscape as pagesize_landscape
 from reportlab.lib.units import mm, cm
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen import canvas
+
+if sys.version_info >= (3,):
+    unicode = str
 
 
 class BoletoPDF(object):

--- a/setup.py
+++ b/setup.py
@@ -21,25 +21,21 @@ def get_version(package):
 
 extra = {}
 if sys.version_info >= (3,):
-    extra['use_2to3'] = True
+    extra['use_2to3'] = False
     #extra['convert_2to3_doctests'] = ['src/your/module/README.txt']
     #extra['use_2to3_fixers'] = ['your.fixers']
     extra['install_requires'] = [
         'distribute',
     ]
-    extra['tests_require'] = [
-        'pep8>=0.6.1',
-        'pep8<1.3',
-    ],
-else:
-    extra['install_requires'] = [
-        'reportlab>=2.5',
-    ]
-    extra['tests_require'] = [
-        'pep8>=0.6.1',
-        'pep8<1.3',
-        'pyflakes>=0.5.0',
-    ]
+
+extra['install_requires'] = [
+    'reportlab>=3.2',
+]
+extra['tests_require'] = [
+    'pep8>=0.6.1',
+    'pep8<1.3',
+    'pyflakes>=0.5.0',
+]
 
 setup(
     name='pyboleto',

--- a/tests/test_pyflakes.py
+++ b/tests/test_pyflakes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vi:si:et:sw=4:sts=4:ts=4
+from __future__ import print_function
 
 ##
 ## Copyright (C) 2011-2012 Async Open Source <http://www.async.com.br>
@@ -31,20 +32,10 @@ import sys
 import unittest
 
 from .testutils import SourceTest
-from .compat import skipIf
+
+from pyflakes import checker
 
 
-try:
-    from pyflakes import checker
-except ImportError as err:
-    if sys.version_info >= (3,):
-        pass  # Pyflakes doesn't support Python3
-    else:
-        raise(err)
-
-
-@skipIf(sys.version_info >= (3,),
-        "Pyflakes unavailable on this version")
 class TestPyflakes(SourceTest, unittest.TestCase):
     def setUp(self):
         pass
@@ -63,24 +54,22 @@ class TestPyflakes(SourceTest, unittest.TestCase):
                 # Avoid using msg, since for the only known case, it contains a
                 # bogus message that claims the encoding the file declared was
                 # unknown.
-                print >> sys.stderr, "%s: problem decoding source" % (
-                    filename,
-                )
+                print("%s: problem decoding source" % (filename), file=sys.stderr)
             else:
                 line = text.splitlines()[-1]
 
                 if offset is not None:
                     offset = offset - (len(text) - len(line))
 
-                print >> sys.stderr, '%s:%d: %s' % (filename, lineno, msg)
-                print >> sys.stderr, line
+                print('%s:%d: %s' % (filename, lineno, msg), file=sys.stderr)
+                print(line, file=sys.stderr)
 
                 if offset is not None:
-                    print >> sys.stderr, " " * offset, "^"
+                    print(" " * offset, "^", file=sys.stderr)
 
             return 1
         except UnicodeError as msg:
-            print >> sys.stderr, 'encoding error at %r: %s' % (filename, msg)
+            print('encoding error at %r: %s' % (filename, msg), file=sys.stderr)
             return 1
         else:
             # Okay, it's syntactically valid.
@@ -94,19 +83,22 @@ class TestPyflakes(SourceTest, unittest.TestCase):
         msgs = []
         result = 0
         try:
-            fd = open(filename, 'U')
+            if sys.version_info >= (3,):
+                fd = open(filename)
+            else:
+                fd = open(filename, 'U')
             try:
                 result = self._check(fd.read(), filename, warnings)
             finally:
                 fd.close()
         except IOError as msg:
-            print >> sys.stderr, "%s: %s" % (filename, msg.args[1])
+            print("%s: %s" % (filename, msg.args[1]), file=sys.stderr)
             result = 1
 
         warnings.sort(key=lambda w: w.lineno)
         for warning in warnings:
             msg = str(warning).replace(root, '')
-            print msg
+            print(msg)
             msgs.append(msg)
         if result:
             raise AssertionError(

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -5,7 +5,6 @@ import difflib
 import fnmatch
 import os
 import re
-import sys
 import subprocess
 import tempfile
 import unittest
@@ -14,16 +13,7 @@ from xml.etree.ElementTree import fromstring, tostring
 
 import pyboleto
 
-from .compat import skipIf
-
-
-try:
-    from pyboleto.pdf import BoletoPDF
-except ImportError as err:
-    if sys.version_info >= (3,):
-        pass  # Reportlab doesn;t support Python3
-    else:
-        raise(err)
+from pyboleto.pdf import BoletoPDF
 
 
 def list_recursively(directory, pattern):
@@ -151,7 +141,9 @@ def pdftoxml(filename, output):
 
     root = fromstring(stdout)
     indent(root)
-    open(output, 'w').write(tostring(root))
+    with open(output, 'w') as f:
+        s = tostring(root)
+        f.write(s.decode('utf-8'))
 
 
 class BoletoTestCase(unittest.TestCase):
@@ -162,8 +154,6 @@ class BoletoTestCase(unittest.TestCase):
             open(fname, 'w').write(open(generated).read())
         return fname
 
-    @skipIf(sys.version_info >= (3,),
-                     "Reportlab unavailable on this version")
     def test_pdf_triplo_rendering(self):
         bank = type(self.dados[0]).__name__
         filename = tempfile.mktemp(prefix="pyboleto-triplo-",
@@ -183,8 +173,6 @@ class BoletoTestCase(unittest.TestCase):
                 bank, diff))
         os.unlink(generated)
 
-    @skipIf(sys.version_info >= (3,),
-                     "Reportlab unavailable on this version")
     def test_pdf_rendering(self):
         dados = self.dados[0]
         bank = type(dados).__name__


### PR DESCRIPTION
Fiz as alterações no código afim de manter uma única base de código que funcionasse no Python 2.7 e 3.4, já que o ReportLab e o Pyflakes já funcionam nele. Por isso, removi do setup.py o 2to3 e fiz uma série de outros ajustes.

Espero ter contribuído :)