### PR TITLE
fix(StringIO) Compatibility with both Python2 and Python3

### DIFF
--- a/pyboleto/django/admin.py
+++ b/pyboleto/django/admin.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from datetime import date
 
 from django.http import HttpResponse


### PR DESCRIPTION
From What’s New In Python 3.0:

> The StringIO and cStringIO modules are gone. Instead, import the io module and use io.StringIO or io.BytesIO for text and data respectively.

Now compatible with both Python2 and Python3.