### PR TITLE
[FIX] Corrige o fator de vencimento do boleto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
-.tox
 
 #Translations
 *.mo
@@ -33,3 +32,8 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 venv
+/.idea/google-java-format.xml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/pyboleto.iml
+/.idea/vcs.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/pyboleto/data.py
+++ b/pyboleto/data.py
@@ -20,7 +20,7 @@ class BoletoException(Exception):
         Exception.__init__(self, message)
 
 
-_EPOCH = datetime.date(1997, 10, 7)
+_EPOCH = datetime.date(2025, 2, 22)
 
 
 class CustomProperty(object):
@@ -209,11 +209,11 @@ class BoletoData(object):
                      value,
                      len(value)))
 
-        due_date_days = (self.data_vencimento - _EPOCH).days
+        due_date_days = (self.data_vencimento - _EPOCH).days + 1000
         if not (9999 >= due_date_days >= 0):
             raise TypeError(
-                "Invalid date, must be between 1997/07/01 and "
-                "2024/11/15")
+                "Invalid date, must be between 2025/02/22 and "
+                "2049/11/15")
         num = "%s%1s%04d%010d%24s" % (self.codigo_banco,
                                       self.moeda,
                                       due_date_days,


### PR DESCRIPTION
Trocando a data base para 2025/02/22 e somando 1000.

O fator de vencimento de um boleto é um número que indica o tempo decorrido desde 7 de outubro de 1997 até a data de vencimento do boleto. Ele é usado no código de barras para facilitar o processamento bancário. 
A partir de 22 de fevereiro de 2025, o fator de vencimento será reiniciado em "1000" e aumentará "1" a cada dia seguinte. 
